### PR TITLE
Explicitly set LINUX_VERSION

### DIFF
--- a/recipes-kernel/linux/linux-imx_5.15.bbappend
+++ b/recipes-kernel/linux/linux-imx_5.15.bbappend
@@ -7,7 +7,7 @@ KERNEL_BRANCH = "somlabs_imx_5.15.52-2.1.0"
 SRCREV = "f91100eddd92d5696c46a6aeea878ea9e6ccb8e4"
 
 LINUX_VERSION = "5.15.52"
-LOCALVERSION = "-somlabs_imx_5.15.52-2.1.0"
+LOCALVERSION = "-somlabs_imx"
 
 IMX_KERNEL_CONFIG_AARCH64:visionsom-8mm-cb = "somlabs_8m_defconfig"
 IMX_KERNEL_CONFIG_AARCH64:visionsbc-8mmini = "somlabs_8m_defconfig"

--- a/recipes-kernel/linux/linux-imx_5.15.bbappend
+++ b/recipes-kernel/linux/linux-imx_5.15.bbappend
@@ -6,6 +6,9 @@ SRC_URI = "${KERNEL_SRC};branch=${KERNEL_BRANCH}"
 KERNEL_BRANCH = "somlabs_imx_5.15.52-2.1.0"
 SRCREV = "f91100eddd92d5696c46a6aeea878ea9e6ccb8e4"
 
+LINUX_VERSION = "5.15.52"
+LOCALVERSION = "-somlabs_imx_5.15.52-2.1.0"
+
 IMX_KERNEL_CONFIG_AARCH64:visionsom-8mm-cb = "somlabs_8m_defconfig"
 IMX_KERNEL_CONFIG_AARCH64:visionsbc-8mmini = "somlabs_8m_defconfig"
 IMX_KERNEL_CONFIG_AARCH64:spacesom-8mplus-cb = "somlabs_8m_defconfig"


### PR DESCRIPTION
Explicitly  set LINUX_VERSION to avoid bitbake errors like:
```
ERROR: linux-imx-5.15.32+gitAUTOINC+f91100eddd-r0 do_kernel_version_sanity_check: Package Version (5.15.32+gitAUTOINC+f91100eddd) does not match of kernel being built (5.15.52). Please update the PV variable to match the kernel source or set KERNEL_VERSION_SANITY_SKIP="1" in your recipe.
```