### PR TITLE
fix LOCALVERSION

### DIFF
--- a/recipes-kernel/linux/linux-imx_5.15.bbappend
+++ b/recipes-kernel/linux/linux-imx_5.15.bbappend
@@ -7,7 +7,7 @@ KERNEL_BRANCH = "somlabs_imx_5.15.52-2.1.0"
 SRCREV = "f91100eddd92d5696c46a6aeea878ea9e6ccb8e4"
 
 LINUX_VERSION = "5.15.52"
-LOCALVERSION = "-somlabs_imx"
+LOCALVERSION = "-somlabs"
 
 IMX_KERNEL_CONFIG_AARCH64:visionsom-8mm-cb = "somlabs_8m_defconfig"
 IMX_KERNEL_CONFIG_AARCH64:visionsbc-8mmini = "somlabs_8m_defconfig"


### PR DESCRIPTION
The underscore character ( _ ) proposed by me in current kernel LOCALVERSION is illegall for generated package names. It leads to errors like this when building external kernel modules:  
```
Subprocess output:kernel-module-8188eu-5.15.52-somlabs_imx+gc41c0aeedfad *** 
Error: Package name kernel-module-8188eu-5.15.52-somlabs_imx+gc41c0aeedfad contains illegal characters, (other than [a-z0-9.+-])
```